### PR TITLE
fix: summoners not tracked on startup

### DIFF
--- a/src/main/java/com/alistats/discorki/DiscorkiApplication.java
+++ b/src/main/java/com/alistats/discorki/DiscorkiApplication.java
@@ -53,7 +53,7 @@ public class DiscorkiApplication implements CommandLineRunner {
 				SummonerDto summonerDto = leagueApiController.getSummoner(summonerName);
 				Summoner summoner = summonerDto.toSummoner();
 				summoner.setIsTracked(true);
-				summonerRepo.save(summonerDto.toSummoner());
+				summonerRepo.save(summoner);
 
 				// Fetch rank
 				List<LeagueEntryDto> leagueEntryDtos = Arrays.asList(leagueApiController.getLeagueEntries(summoner.getId()));


### PR DESCRIPTION
Closes #26 

Issue was not caused by usernames with strings but by wrongly passed variable.